### PR TITLE
feat(publish): Add artifact steps to publish workflow

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   setup-and-run-hugo:
-    name: Test
+    name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -30,10 +30,18 @@ jobs:
 
       - name: Setup Hugo
         # TODO find correct tag so action doesn't fail with file not found error
-        uses: peaceiris/actions-hugo@v3.0.0
+        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
         with:
           hugo-version: ${{ steps.hugo-version.outputs.HUGO_VERSION }}
           extended: true
 
       - name: Build website
         run: hugo --minify
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v.4.3.6
+        with:
+          name: 3ware-website
+          path: ./public
+          retention-days: 1
+          overwrite: true

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -36,4 +36,4 @@ jobs:
     # `name: Test` in hugo.yaml
     name: Test
     needs: [lint]
-    uses: 3ware/www-src/.github/workflows/hugo.yaml@2e5314429b97aecc4354ba42a5ba0fb0c287b1ec # v2.0.0
+    uses: 3ware/www-src/.github/workflows/hugo.yaml@ref-hugo-publish-workflow

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,6 @@ name: Publish Website
 on:
   release:
     types: [published]
-  workflow_dispatch: {}
 
 # Disable permissions for all available scopes
 permissions: {}
@@ -14,6 +13,7 @@ jobs:
     uses: 3ware/www-src/.github/workflows/hugo.yaml@2e5314429b97aecc4354ba42a5ba0fb0c287b1ec # v2.0.0
 
   publish-website:
+    name: Publish
     needs: [build-website]
     runs-on: ubuntu-latest
     concurrency:
@@ -21,9 +21,14 @@ jobs:
       cancel-in-progress: true
     timeout-minutes: 10
     steps:
+      - name: Download artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: 3ware-website
+          path: ./public
+
       - name: Publish
-        # TODO: find correct tag so action doesn't fail with file not found error
-        uses: peaceiris/actions-gh-pages@v4.0.0
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           deploy_key: ${{ secrets.ACTION_DEPLOY_KEY }}
           external_repository: 3ware/www-public


### PR DESCRIPTION
The workflow to setup hugo and build to website is reusable and is currently used between lint-and-test and publish to avoid code being reused in those workflows.

Consequently, in the publish workflow, `Build` and `Publish` are separate jobs because reusable workflows must be called at the job level which means that the output from the `Build` job must be uploaded as an artifact and downloaded in the `Publish` job.

Would it be easier to just reuse to `hugo` code on each workflow? Possibly, but I thought it would be useful to learn about how artifacts are shared between jobs.